### PR TITLE
Refactor model struct generation

### DIFF
--- a/model_template.go
+++ b/model_template.go
@@ -2,7 +2,7 @@ package gorma
 
 const modelTmpl = `// {{if .Description}}{{.Description}}{{else}}app.{{gotypename . 0}} storage type{{end}}
 // Identifier: {{ $typeName :=  gotypename . 0}}{{$typeName := demodel $typeName}}
-{{$td := gotypedef . 0 true false}}type {{$typeName}} {{modeldef $td .}}
+type {{$typeName}} {{ modeldef . }}
 {{ $belongsto := index .Metadata "github.com/bketelsen/gorma#belongsto" }}
 {{ $m2m := index .Metadata "github.com/bketelsen/gorma#many2many" }}
 {{ $nomedia := index .Metadata "github.com/bketelsen/gorma#nomedia" }}

--- a/modelwriter.go
+++ b/modelwriter.go
@@ -19,7 +19,7 @@ type ModelWriter struct {
 func NewModelWriter(filename string) (*ModelWriter, error) {
 	cw := codegen.NewGoGenerator(filename)
 	funcMap := cw.FuncMap
-	funcMap["gotypedef"] = GoTypeDef
+	funcMap["gotypedef"] = codegen.GoTypeDef
 	funcMap["gotyperef"] = codegen.GoTypeRef
 	funcMap["goify"] = codegen.Goify
 	funcMap["gotypename"] = codegen.GoTypeName


### PR DESCRIPTION
This commit makes `MakeModelDef` mimic `codegen.godef` as our entry point. It
calls `codegen.GoTypeDef` for subsequent attibute definitions.

The "duplicate ID removal hack" has been replaced by the `setupIDAttibution`
function.  It's job is to insert an ID attribute into the model or update an
existing one if it's already defined.

I also added a `genfuncs` map that we spin through to add extra fields and
comment the blocks as we go.