### PR TITLE
Update function names

### DIFF
--- a/gorma.go
+++ b/gorma.go
@@ -33,7 +33,7 @@ func NewGenerator() (*Generator, error) {
 // Generate produces the generated model files
 func (g *Generator) Generate(api *design.APIDefinition) ([]string, error) {
 
-	os.MkdirAll(ModelDir(), 0755)
+	os.MkdirAll(modelDir(), 0755)
 	app := kingpin.New("Model generator", "model generator")
 	codegen.RegisterFlags(app)
 	_, err := app.Parse(os.Args[1:])
@@ -76,9 +76,9 @@ func (g *Generator) Generate(api *design.APIDefinition) ([]string, error) {
 	err = api.IterateUserTypes(func(res *design.UserTypeDefinition) error {
 		if res.Type.IsObject() {
 			title := fmt.Sprintf("%s: Models", api.Name)
-			modelname := strings.ToLower(DeModel(res.TypeName))
+			modelname := strings.ToLower(deModel(res.TypeName))
 
-			filename := filepath.Join(ModelDir(), modelname+"_genmodel.go")
+			filename := filepath.Join(modelDir(), modelname+"_genmodel.go")
 			os.Remove(filename)
 			mtw, err := NewModelWriter(filename)
 			if err != nil {
@@ -108,7 +108,7 @@ func (g *Generator) Generate(api *design.APIDefinition) ([]string, error) {
 
 	})
 	if dorbac {
-		rbacfilename := filepath.Join(ModelDir(), "rbac_genmodel.go")
+		rbacfilename := filepath.Join(modelDir(), "rbac_genmodel.go")
 		os.Remove(rbacfilename)
 		rbacw, err := NewRbacWriter(rbacfilename)
 		if err != nil {

--- a/helpers.go
+++ b/helpers.go
@@ -14,12 +14,12 @@ import (
 )
 
 // TitleCase converts a string to Title case.
-func TitleCase(s string) string {
+func titleCase(s string) string {
 	return strings.Title(s)
 }
 
 // CamelToSnake converts a given string to snake case.
-func CamelToSnake(s string) string {
+func camelToSnake(s string) string {
 	var result string
 	var words []string
 	var lastPos int
@@ -57,28 +57,28 @@ func CamelToSnake(s string) string {
 }
 
 // ModelDir is the path to the directory where the schema controller is generated.
-func ModelDir() string {
+func modelDir() string {
 	return filepath.Join(codegen.OutputDir, "models")
 }
 
 // DeModel remove the word "Model" from the string.
-func DeModel(s string) string {
+func deModel(s string) string {
 	return strings.Replace(s, "Model", "", -1)
 }
 
 // Lower returns the string in lowercase.
-func Lower(s string) string {
+func lower(s string) string {
 	return strings.ToLower(s)
 }
 
 // Upper returns the string in upper case.
-func Upper(s string) string {
+func upper(s string) string {
 	return strings.ToUpper(s)
 }
 
 // StorageDefinition creates the storage interface that will be used
 // in place of a concrete type for testability.
-func StorageDefinition(res *design.UserTypeDefinition) string {
+func StorageDef(res *design.UserTypeDefinition) string {
 	var associations string
 	if assoc, ok := res.Metadata["github.com/bketelsen/gorma#many2many"]; ok {
 		children := strings.Split(assoc, ",")
@@ -95,7 +95,7 @@ func StorageDefinition(res *design.UserTypeDefinition) string {
 
 // IncludeForeignKey adds foreign key relations to the struct being
 // generated.
-func IncludeForeignKey(res *design.AttributeDefinition) string {
+func includeForeignKey(res *design.AttributeDefinition) string {
 	var associations string
 	if assoc, ok := res.Metadata["github.com/bketelsen/gorma#belongsto"]; ok {
 		children := strings.Split(assoc, ",")
@@ -109,13 +109,13 @@ func IncludeForeignKey(res *design.AttributeDefinition) string {
 }
 
 // Plural returns the plural version of a word.
-func Plural(s string) string {
+func plural(s string) string {
 	return inflection.Plural(s)
 }
 
 // IncludeChildren adds the fields to a struct represented
 // in a has-many relationship.
-func IncludeChildren(res *design.AttributeDefinition) string {
+func includeChildren(res *design.AttributeDefinition) string {
 	var associations string
 	if assoc, ok := res.Metadata["github.com/bketelsen/gorma#hasmany"]; ok {
 		children := strings.Split(assoc, ",")
@@ -136,7 +136,7 @@ func IncludeChildren(res *design.AttributeDefinition) string {
 
 // IncludeMany2Many returns the appropriate struct tags
 // for a m2m relationship in gorm.
-func IncludeMany2Many(res *design.AttributeDefinition) string {
+func includeMany2Many(res *design.AttributeDefinition) string {
 	var associations string
 	if assoc, ok := res.Metadata["github.com/bketelsen/gorma#many2many"]; ok {
 		children := strings.Split(assoc, ",")
@@ -151,7 +151,7 @@ func IncludeMany2Many(res *design.AttributeDefinition) string {
 
 // Authboss returns the tags required to implement authboss storage.
 // Currently experimental and quite unfinished.
-func Authboss(res *design.AttributeDefinition) string {
+func includeAuthboss(res *design.AttributeDefinition) string {
 	if _, ok := res.Metadata["github.com/bketelsen/gorma#authboss"]; ok {
 		fields := `	// Auth
 	Password string
@@ -182,12 +182,12 @@ func Authboss(res *design.AttributeDefinition) string {
 }
 
 // Split splits a string by separater `sep`.
-func Split(s string, sep string) []string {
+func split(s string, sep string) []string {
 	return strings.Split(s, sep)
 }
 
 // TimeStamps returns the timestamp fields if "skipts" isn't set.
-func TimeStamps(res *design.AttributeDefinition) string {
+func includeTimeStamps(res *design.AttributeDefinition) string {
 	var ts string
 	if _, ok := res.Metadata["github.com/bketelsen/gorma#skipts"]; ok {
 		ts = ""
@@ -198,7 +198,7 @@ func TimeStamps(res *design.AttributeDefinition) string {
 }
 
 // MakeModelDef is the main function to create a struct definition.
-func MakeModelDef(res *design.UserTypeDefinition) string {
+func ModelDef(res *design.UserTypeDefinition) string {
 	var buffer bytes.Buffer
 	def := res.Definition()
 	t := def.Type
@@ -324,11 +324,11 @@ func startsWithInitialism(s string) string {
 // content, the content will be preceded by the the map key, which should be a
 // comment.
 var genfuncs = map[string]func(*design.AttributeDefinition) string{
-	"\n// Timestamps\n":   TimeStamps,
-	"\n// Many2Many\n":    IncludeMany2Many,
-	"\n// Foreign Keys\n": IncludeForeignKey,
-	"\n// Children\n":     IncludeChildren,
-	"\n// Authboss\n\n":   Authboss,
+	"\n// Timestamps\n":   includeTimeStamps,
+	"\n// Many2Many\n":    includeMany2Many,
+	"\n// Foreign Keys\n": includeForeignKey,
+	"\n// Children\n":     includeChildren,
+	"\n// Authboss\n\n":   includeAuthboss,
 }
 
 // commonInitialisms, taken from

--- a/modelwriter.go
+++ b/modelwriter.go
@@ -28,14 +28,14 @@ func NewModelWriter(filename string) (*ModelWriter, error) {
 	funcMap["typeMarshaler"] = codegen.MediaTypeMarshaler
 	funcMap["recursiveValidate"] = codegen.RecursiveChecker
 	funcMap["tempvar"] = codegen.Tempvar
-	funcMap["demodel"] = DeModel
-	funcMap["modeldef"] = MakeModelDef
-	funcMap["snake"] = CamelToSnake
-	funcMap["split"] = Split
-	funcMap["storagedef"] = StorageDefinition
-	funcMap["lower"] = Lower
-	funcMap["title"] = TitleCase
-	funcMap["plural"] = Plural
+	funcMap["demodel"] = deModel
+	funcMap["modeldef"] = ModelDef
+	funcMap["snake"] = camelToSnake
+	funcMap["split"] = split
+	funcMap["storagedef"] = StorageDef
+	funcMap["lower"] = lower
+	funcMap["title"] = titleCase
+	funcMap["plural"] = plural
 
 	modelTmpl, err := template.New("models").Funcs(funcMap).Parse(modelTmpl)
 	if err != nil {

--- a/rbacwriter.go
+++ b/rbacwriter.go
@@ -28,11 +28,11 @@ func NewRbacWriter(filename string) (*RbacWriter, error) {
 	funcMap["typeMarshaler"] = codegen.MediaTypeMarshaler
 	funcMap["recursiveValidate"] = codegen.RecursiveChecker
 	funcMap["tempvar"] = codegen.Tempvar
-	funcMap["demodel"] = DeModel
-	funcMap["modeldef"] = MakeModelDef
-	funcMap["snake"] = CamelToSnake
-	funcMap["lower"] = Lower
-	funcMap["upper"] = Upper
+	funcMap["demodel"] = deModel
+	funcMap["modeldef"] = ModelDef
+	funcMap["snake"] = camelToSnake
+	funcMap["lower"] = lower
+	funcMap["upper"] = upper
 
 	rbacTmpl, err := template.New("rbac").Funcs(funcMap).Parse(rbacTmpl)
 	if err != nil {


### PR DESCRIPTION
Used gorename to privatize most functions and rename a few:

- Authboss => includeAuthboss
- MakeModelDef => ModelDef
- StorageDefinition => StorageDef
- TimeStamps => includeTimeStamps

Should not change functionality.  Just makes the GoDocs cleaner.