### PR TITLE
Allow mixed case metadata tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,52 +47,52 @@ Metadata("github.com/bketelsen/gorma", "Model")
 
 This tag is required in your model in order for gorma to process it.
 
-### belongsto
+### belongsTo
 ```
-Metadata("github.com/bketelsen/gorma#belongsto", "User")
+Metadata("github.com/bketelsen/gorma#belongsTo", "User")
 ```
 **Scope:** Model
 
 This tag denotes that the model "belongs to" a parent, e.g. Proposal "Belongs To" User.
 Multiple `belongsto` relationships can be expressed by including them as comma separated entities.
 
-### dyntablename
+### dynTableName
 ```
-	Metadata("github.com/bketelsen/gorma#dyntablename", "true")
+	Metadata("github.com/bketelsen/gorma#dynTableName", "true")
 ```
 **Scope:** Model
 
 This tag denotes that the given model requires a dynamic table name causing
 gorma to generate a `tableName` field to relevant function signatures.
 
-### gormpktag
+### gormPKTag
 ```
-	Metadata("github.com/bketelsen/gorma#gormpktag", "column:users_id;primary")
+	Metadata("github.com/bketelsen/gorma#gormPKTag", "column:users_id;primary")
 ```
 **Scope:** Model
 
 This tag is used in the Model scope to denote `gorm` tags that need to be used for the auto-generated ID field.
 
-### gormtag
+### gormTag
 ```
-	Metadata("github.com/bketelsen/gorma#gormtag", "column:first_name")
+	Metadata("github.com/bketelsen/gorma#gormTag", "column:first_name")
 ```
 **Scope:** Attribute
 
 This tag is used in the Attribute scope to denote `gorm` tags that need to be added to the generated struct.
 
-### hasmany
+### hasMany
 ```
-Metadata("github.com/bketelsen/gorma#hasmany", "Proposal,Review")
+Metadata("github.com/bketelsen/gorma#hasMany", "Proposal,Review")
 ```
 **Scope:** Model
 
 This tag denotes the model as being the parent in a "Has Many" relationship, e.g. User "Has Many" Proposals.
 Multiple `hasmany` relationships can be expressed by including them as comma separated entities.
 
-### hasone
+### hasOne
 ```
-Metadata("github.com/bketelsen/gorma#hasone", "Address")
+Metadata("github.com/bketelsen/gorma#hasOne", "Address")
 ```
 **Scope:** Model
 
@@ -116,9 +116,9 @@ table called `company_industries` and a field in the Company struct called
 Metadata("github.com/bketelsen/gorma#many2many", "Industries:Industry:company_industries")
 ```
 
-### nomedia
+### noMedia
 ```
-	Metadata("github.com/bketelsen/gorma#nomedia", "true")
+	Metadata("github.com/bketelsen/gorma#noMedia", "true")
 ```
 **Scope:** Model
 
@@ -132,27 +132,28 @@ This feature is useful when you want gorma to generate code for models that are 
 **Scope:** Model
 
 This tag adds a GetRole() function to the model, and returns the "Role" field of the model.  To be used with the RBAC tag.
+Requires [github.com/mikespook/gorbac](https://github.com/mikespook/gorbac).
 
-### sqltag
+### sqlTag
 ```
-	Metadata("github.com/bketelsen/gorma#sqltag", "size:255")
+	Metadata("github.com/bketelsen/gorma#sqlTag", "size:255")
 ```
 **Scope:** Attribute
 
 This tag is used in the Attribute scope to denote `sql` tags that need to be added to the generated struct.
 
-### tablename
+### tableName
 ```
-	Metadata("github.com/bketelsen/gorma#tablename", "example.users")
+	Metadata("github.com/bketelsen/gorma#tableName", "example.users")
 ```
 **Scope:** Model
 
 This tag denotes that the underlying table name does not match gorm conventions.
 The metadata argument is used as the table name in the generated model.
 
-### skipts
+### skipTS
 ```
-	Metadata("github.com/bketelsen/gorma#skipts", "true")
+	Metadata("github.com/bketelsen/gorma#skipTS", "true")
 ```
 **Scope:** Model
 

--- a/gorma.go
+++ b/gorma.go
@@ -61,8 +61,8 @@ func (g *Generator) Generate(api *design.APIDefinition) ([]string, error) {
 	}
 
 	rbactitle := fmt.Sprintf("%s: RBAC", api.Name)
-	_, dorbac := api.Metadata["github.com/bketelsen/gorma#rbac"]
-	_, cached := api.Metadata["github.com/bketelsen/gorma#cached"]
+	_, dorbac := metaLookup(api.Metadata, "#rbac")
+	_, cached := metaLookup(api.Metadata, "#cached")
 	if cached {
 		imports = []*codegen.ImportSpec{
 			codegen.SimpleImport(appPkg),
@@ -85,7 +85,7 @@ func (g *Generator) Generate(api *design.APIDefinition) ([]string, error) {
 				panic(err)
 			}
 			mtw.WriteHeader(title, "models", imports)
-			if md, ok := res.Metadata["github.com/bketelsen/gorma"]; ok && md == "Model" {
+			if md, ok := metaLookup(res.Metadata, ""); ok && md == "Model" {
 				err = mtw.Execute(res)
 				if err != nil {
 					fmt.Println("Error executing Gorma: ", err.Error())

--- a/model_template.go
+++ b/model_template.go
@@ -3,9 +3,9 @@ package gorma
 const modelTmpl = `// {{if .Description}}{{.Description}}{{else}}app.{{gotypename . 0}} storage type{{end}}
 // Identifier: {{ $typeName :=  gotypename . 0}}{{$typeName := demodel $typeName}}
 type {{$typeName}} {{ modeldef . }}
-{{ $belongsto := index .Metadata "github.com/bketelsen/gorma#belongsto" }}
-{{ $m2m := index .Metadata "github.com/bketelsen/gorma#many2many" }}
-{{ $nomedia := index .Metadata "github.com/bketelsen/gorma#nomedia" }}
+{{ $belongsto := metaLookup .Metadata "#belongsto" }}
+{{ $m2m := metaLookup .Metadata "#many2many" }}
+{{ $nomedia := metaLookup .Metadata "#nomedia" }}
 {{ if eq $nomedia "" }}
 func {{$typeName}}FromCreatePayload(ctx *app.Create{{demodel $typeName}}Context) {{$typeName}} {
 	payload := ctx.Payload
@@ -29,20 +29,20 @@ func (m {{$typeName}}) ToApp() *app.{{demodel $typeName}} {
 	return &target
 }
 {{ end }}
-{{ $tablename := index .Metadata "github.com/bketelsen/gorma#tablename" }}
+{{ $tablename := metaLookup .Metadata "#tablename" }}
 {{ if ne $tablename "" }}
 func (m {{$typeName}}) TableName() string {
 	return "{{ $tablename }}"
 }
 {{ end }}
-{{ $roler := index .Metadata "github.com/bketelsen/gorma#roler" }}
+{{ $roler := metaLookup .Metadata "#roler" }}
 {{ if ne $roler "" }}
 func (m {{$typeName}}) GetRole() string {
 	return m.Role
 }
 {{end}}
 
-{{ $dyntablename := index .Metadata "github.com/bketelsen/gorma#dyntablename" }}
+{{ $dyntablename := metaLookup .Metadata "#dyntablename" }}
 
 type {{$typeName}}Storage interface {
 	List(ctx context.Context{{ if ne $dyntablename "" }}, tableName string{{ end }}) []{{$typeName}}
@@ -56,7 +56,7 @@ type {{$typeName}}Storage interface {
 {{end}}{{end}}
 	{{ storagedef . }}
 }
-{{ $cached := index .Metadata "github.com/bketelsen/gorma#cached" }}
+{{ $cached := metaLookup .Metadata "#cached" }}
 type {{$typeName}}DB struct {
 	DB gorm.DB
 	{{ if ne $cached "" }}cache *cache.Cache{{end}}

--- a/modelwriter.go
+++ b/modelwriter.go
@@ -36,6 +36,7 @@ func NewModelWriter(filename string) (*ModelWriter, error) {
 	funcMap["lower"] = lower
 	funcMap["title"] = titleCase
 	funcMap["plural"] = plural
+	funcMap["metaLookup"] = metaLookupTmpl
 
 	modelTmpl, err := template.New("models").Funcs(funcMap).Parse(modelTmpl)
 	if err != nil {


### PR DESCRIPTION
This commit adds support for mixed case metadata tags.  It should be backwards
compatible.

I added a `metaLookup` helper function and a companion `metaLookupTmpl` function
that the templates use (although it's exposed as `metaLookup` in the templates).
Updated README to use camelCase for tags names.

Fixes #8