### PR TITLE
Multiple fixes to generator

### DIFF
--- a/dsl/relationalfield.go
+++ b/dsl/relationalfield.go
@@ -26,7 +26,7 @@ func Field(name string, args ...interface{}) {
 	// standardize field name definitions
 	name = codegen.Goify(name, true)
 	if strings.HasSuffix(name, "Id") {
-		name = strings.TrimRight(name, "Id")
+		name = strings.TrimSuffix(name, "Id")
 		name = name + "ID"
 	}
 	fieldType, dsl := parseModelArgs(args...)
@@ -67,7 +67,7 @@ func Field(name string, args ...interface{}) {
 
 		field.DatabaseFieldName = inflect.Underscore(name)
 		if strings.HasSuffix(field.DatabaseFieldName, "_i_d") {
-			field.DatabaseFieldName = strings.TrimRight(field.DatabaseFieldName, "_i_d")
+			field.DatabaseFieldName = strings.TrimSuffix(field.DatabaseFieldName, "_i_d")
 			field.DatabaseFieldName = field.DatabaseFieldName + "_id"
 		}
 		s.RelationalFields[name] = field

--- a/relationalmodel.go
+++ b/relationalmodel.go
@@ -123,11 +123,12 @@ func (f *RelationalModelDefinition) IterateFields(it FieldIterator) error {
 
 	// Sort only the fields that aren't pk or date
 	j := 0
-	sortfields := make([]string, len(names))
+	sortnames := make([]string, len(names))
 	for n := range names {
-		sortfields[j] = n
+		sortnames[j] = n
+		j++
 	}
-	sort.Strings(sortfields)
+	sort.Strings(sortnames)
 
 	// Put them back together
 	j = 0
@@ -137,7 +138,7 @@ func (f *RelationalModelDefinition) IterateFields(it FieldIterator) error {
 		fields[j] = pk
 		j++
 	}
-	for _, name := range names {
+	for _, name := range sortnames {
 		fields[j] = name
 		j++
 	}
@@ -170,7 +171,7 @@ func (f *RelationalModelDefinition) PopulateFromModeledType() {
 			rf.Parent = f
 			rf.Name = codegen.Goify(name, true)
 			if strings.HasSuffix(rf.Name, "Id") {
-				rf.Name = strings.TrimRight(rf.Name, "Id")
+				rf.Name = strings.TrimSuffix(rf.Name, "Id")
 				rf.Name = rf.Name + "ID"
 			}
 			switch att.Type.Kind() {

--- a/writers.go
+++ b/writers.go
@@ -89,18 +89,18 @@ func fieldAssignmentTypeToModel(model *RelationalModelDefinition, ut *design.Use
 				}
 				if !upointer && !mpointer {
 					// tfield = mfield
-					fa = fmt.Sprintf("\t%s.%s = %s.%s", mtype, fname, utype, strings.Title(key))
+					fa = fmt.Sprintf("\t%s.%s = %s.%s", mtype, fname, utype, codegen.Goify(key, true))
 				} else if upointer && mpointer {
 					// tfield = mfield
-					fa = fmt.Sprintf("\t%s.%s = %s.%s", mtype, fname, utype, strings.Title(key))
+					fa = fmt.Sprintf("\t%s.%s = %s.%s", mtype, fname, utype, codegen.Goify(key, true))
 
 				} else if upointer {
 					// tfield = &mfield
-					fa = fmt.Sprintf("\t%s.%s = *%s.%s", mtype, fname, utype, strings.Title(key))
+					fa = fmt.Sprintf("\t%s.%s = *%s.%s", mtype, fname, utype, codegen.Goify(key, true))
 
 				} else if mpointer {
 					// tfield = *mfield (rare if never?)
-					fa = fmt.Sprintf("\t%s.%s = *%s.%s", mtype, fname, utype, strings.Title(key))
+					fa = fmt.Sprintf("\t%s.%s = *%s.%s", mtype, fname, utype, codegen.Goify(key, true))
 				}
 				fieldAssignments = append(fieldAssignments, fa)
 
@@ -332,19 +332,19 @@ func Filter{{$typename}}By{{$bt.Name}}(parent *int, list []{{$typename}}) []{{$t
 }
 {{end}}
 
-{{$ap := .AppPkg}}{{ if gt (len .UserType.RenderTo) 0 }}{{$ut := .UserType}}{{range  $tcd := $ut.RenderTo }}{{if $tcd.SupportsNoVersion}}
+{{$ap := .AppPkg}}{{ if gt (len .UserType.RenderTo) 0 }}{{$ut := .UserType}}{{range  $tcd := $ut.RenderTo }}{{if $tcd.SupportsNoVersion}}{{ $tcdTypeName := goify $tcd.TypeName true }}
 // Useful conversion functions
-func (m *{{$typeName}}) To{{$tcd.TypeName}}() {{$ap}}.{{$tcd.TypeName}} {
-	payload := {{$ap}}.{{$tcd.TypeName}}{}
+func (m *{{$typeName}}) To{{$tcdTypeName}}() {{$ap}}.{{$tcdTypeName}} {
+	payload := {{$ap}}.{{$tcdTypeName}}{}
 	{{ famt $ut $tcd "m" "payload"}}
 	return payload
 }
 {{end}}{{end}}{{end}}
 
-{{$ap := .AppPkg}}{{ if gt (len .UserType.RenderTo) 0 }}{{$ut := .UserType}}{{range  $tcd := $ut.RenderTo }}{{ range $version := $tcd.APIVersions }} // v{{$version}}
+{{$ap := .AppPkg}}{{ if gt (len .UserType.RenderTo) 0 }}{{$ut := .UserType}}{{range  $tcd := $ut.RenderTo }}{{ range $version := $tcd.APIVersions }}{{ $tcdTypeName := goify $tcd.TypeName true }} // v{{$version}}
 // Useful conversion functions
-func (m *{{$typeName}}) To{{$tcd.TypeName}}() {{$version}}.{{$tcd.TypeName}} {
-	payload := {{$version}}.{{$tcd.TypeName}}{}
+func (m *{{$typeName}}) To{{$tcdTypeName}}() {{$version}}.{{$tcdTypeName}} {
+	payload := {{$version}}.{{$tcdTypeName}}{}
 	{{ famt $ut $tcd "m" "payload"}}
 	return payload
 }


### PR DESCRIPTION
- Use TrimSuffix instead of TrimRight.
- Only print comments on fields with a description.
- Refactor the tags() func.
- Add Field Alias as a gorma tag, not an sql tag.
- Fix struct field sorting in IterateFields.
- Fix field name generation in fieldAssignmentTypeToModel.
- Fix TypeName generation in To* funcs.